### PR TITLE
[ stack ] Bump to LTS 13.28 for GHC 8.6.5

### DIFF
--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -3,7 +3,6 @@ resolver: lts-9.21
 extra-deps:
 - async-2.2.1
 - text-1.2.3.1
-- tasty-silver-3.1.13
 
 
 # Local packages, usually specified by relative directory name

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -3,10 +3,3 @@ resolver: lts-11.22
 extra-deps:
 - async-2.2.1
 - text-1.2.3.1
-- tasty-silver-3.1.13
-
-# Local packages, usually specified by relative directory name
-packages:
-- '.'
-- 'src/fix-agda-whitespace'
-- 'src/size-solver'

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -1,10 +1,1 @@
 resolver: lts-12.26
-
-extra-deps:
-- tasty-silver-3.1.13
-
-# Local packages, usually specified by relative directory name
-packages:
-- '.'
-- 'src/fix-agda-whitespace'
-- 'src/size-solver'

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.21
+resolver: lts-13.28
 
 extra-deps:
 - EdisonCore-1.3.2.1
@@ -7,5 +7,3 @@ extra-deps:
 - geniplate-mirror-0.7.6
 - EdisonAPI-1.3.1
 - STMonadTrans-0.4.3
-- tasty-silver-3.1.13
-


### PR DESCRIPTION
... and remove redundant package dependency (introduced by myself recently)